### PR TITLE
Serializable event keys

### DIFF
--- a/.changeset/smart-wasps-add.md
+++ b/.changeset/smart-wasps-add.md
@@ -1,0 +1,5 @@
+---
+"@rocket-science-core/event-client": major
+---
+
+Internal tracking of listeners will now be stored by serializing the user provided event type and event key to avoid bug where additional event listeners of the same time are overriden. This is more in line with the way event listeners work in the browser except our implementation allows users to add and remove events by a serializable key. This is a major api change but required.


### PR DESCRIPTION
Required change to internally store listeners by a serializable key provided by the user. This is necessary to maintain functionality with how event listeners work in the browser.