### PR TITLE
Feat/remove all

### DIFF
--- a/.changeset/eight-melons-beam.md
+++ b/.changeset/eight-melons-beam.md
@@ -1,0 +1,5 @@
+---
+"@rocket-science/event-client": minor
+---
+
+New removeAll method will iterate through internally stored listeners and remove them from window as well as remove from the internal store. API documentation updated. Unit tests added.

--- a/docs/event-client/overview.md
+++ b/docs/event-client/overview.md
@@ -288,6 +288,10 @@ const eventsClient = new EventsClient<HostListeners, HostEmitters>();
   - The context (`ctx`) of the event is the payload.
 - `invoke: (type: EventType, ctx: Listeners[EventType]["detail"]): void`
   - Synonymous in functionality with `emit` but will provide type definitions for emitting a client's Listener.
+- `getListeners: (): typeof this.listeners`
+  - A function to get access to the internal Map that holds the listeners for the client.
+- `removeAll: (): void`
+  - A function that will remove all listeners registered in the client.
 
 ## Examples
 

--- a/packages/event-client/src/EventClient.ts
+++ b/packages/event-client/src/EventClient.ts
@@ -122,6 +122,17 @@ export class EventsClient<
   }
 
   /**
+   * Removes all listeners registered in the client.
+   * @returns void
+   * @example client.removeAll();
+   */
+  removeAll() {
+    this.listeners.forEach((_, key) => {
+      this.remove(this.deserializeKey(key));
+    });
+  }
+
+  /**
    * Serialize a `MapKey` to a string.
    * @param type The event type.
    * @param key The event key.
@@ -130,5 +141,15 @@ export class EventsClient<
    */
   private serializeKey({ type, key }: MapKey<keyof Listeners>): string {
     return JSON.stringify({ type, key });
+  }
+
+  /**
+   * Deserialize a stringified `MapKey` to a `MapKey`.
+   * @param key A stringified `MapKey`.
+   * @returns A `MapKey`.
+   * @example const deserialized = client.deserializeKey('{"type":"click","key":"button"}');
+   */
+  private deserializeKey(key: string): MapKey<keyof Listeners> {
+    return JSON.parse(key);
   }
 }

--- a/packages/event-client/src/__tests__/EventClient.test.ts
+++ b/packages/event-client/src/__tests__/EventClient.test.ts
@@ -61,4 +61,24 @@ describe("EventClient", () => {
     client.remove({ type: "test", key: "test" });
     expect(client.getListeners().size).toBe(0);
   });
+  it("clear method should remove all events from listeners and window", () => {
+    jest
+      .spyOn(window, "removeEventListener")
+      .mockImplementationOnce(
+        (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: boolean | EventListenerOptions
+        ) => {
+          expect(type).toBe("test");
+          expect(listener).toBeInstanceOf(Function);
+          expect(options).toBeUndefined();
+        }
+      );
+    client.on("test", "test", ({ detail }) => {
+      expect(detail).toEqual({ test: "test" });
+    });
+    client.removeAll();
+    expect(client.getListeners().size).toBe(0);
+  });
 });


### PR DESCRIPTION
New
- `removeAll` method will iterate through internally stored listeners and remove them from `window` as well as remove from the internal store.
- `private deserialized` method to retrieve listeners by their serialized key from storage.
- Documentation added
- Tests added